### PR TITLE
tailwind 반응형 모바일 해상도 지정

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,9 @@ module.exports = {
         articleColor: "#d7d7fa",
       },
     },
+    screens: {
+      sm: "360px", // mobile 사이즈로 설정
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
기존 sm: 사이즈가 640px이였으나 360px로 변경함
sm: "tailwind스타일 클래스명" 으로 사용하면 됌